### PR TITLE
add header fix erro cv' does not name a type

### DIFF
--- a/include/TLD.h
+++ b/include/TLD.h
@@ -1,4 +1,5 @@
 #include <opencv2/opencv.hpp>
+#include <opencv2/legacy/legacy.hpp>
 #include <tld_utils.h>
 #include <LKTracker.h>
 #include <FerNNClassifier.h>


### PR DESCRIPTION
fix compiling erro " `PatchGenerator' in namespace `cv' does not name a type."  OpenCV2.4.9 ubuntu14.04
sol:
add in TLD.h
#include <opencv2/legacy/legacy.hpp>
